### PR TITLE
added offset + limit capabilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,24 @@ var NO_BYTE = -1;
 
 module.exports = {
 
-	encode: function(buf) {
+    /**
+     * encode from buffer to base65536 string
+     * @param buf -- input buffer
+     * @param offset (optional) starting byte to read from
+     * @param limit (optional) total number of bytes to process
+     *
+     * If offset is omitted, 0 is used.
+     * If limit is omitted, it will read till last byte in buffer.
+     **/
+	encode: function(buf, offset, limit) {
 		var strs = [];
-		for(var i = 0; i < buf.length; i += 2) {
+        if(offset === undefined) {
+            offset = 0;
+        }
+        if(limit === undefined) {
+            limit = buf.length - offset;
+        }
+		for(var i = offset; i < (limit + offset); i += 2) {
 			var b1 = buf[i];
 			var b2 = i + 1 < buf.length ? buf[i + 1] : NO_BYTE;
 			var codePoint = get_block_start[b2] + b1;

--- a/index.js
+++ b/index.js
@@ -32,9 +32,10 @@ module.exports = {
         if(limit === undefined) {
             limit = buf.length - offset;
         }
-		for(var i = offset; i < (limit + offset); i += 2) {
+        limit = limit + offset;
+		for(var i = offset; i < limit; i += 2) {
 			var b1 = buf[i];
-			var b2 = i + 1 < buf.length ? buf[i + 1] : NO_BYTE;
+			var b2 = i + 1 < limit ? buf[i + 1] : NO_BYTE;
 			var codePoint = get_block_start[b2] + b1;
 			var str = String.fromCodePoint(codePoint);
 			strs.push(str);


### PR DESCRIPTION
Hello!

I am using Your library as a effective storage.

Anything is fine, but in serialization process I have some code which writes some butes in a buffer which size is much more than bytes which I should encode.

If course, I can create a temporary buffer with proper size and copy data there, but better to introduce limit+offset feature (which is quite common).

This pull request do the job.

Tests are passing.